### PR TITLE
Adding missing eslint devDependency

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -30,6 +30,7 @@
   ],
   "devDependencies": {
     "chai": "^3.5.0",
+    "eslint": "^2.10.2",
     "eslint-config-screwdriver": "^1.0.0",
     "eslint-plugin-import": "^1.8.0",
     "eslint-plugin-jsx-a11y": "^1.2.2",


### PR DESCRIPTION
Looks like we were missing the eslint dev dependency.  This adds it back.