### PR TITLE
Change to .eslintrc.yaml. Fix lint errors in templates.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-    "extends": "screwdriver"
-}

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,0 +1,1 @@
+extends: screwdriver

--- a/app/index.js
+++ b/app/index.js
@@ -1,3 +1,4 @@
+'use strict';
 const yeoman = require('yeoman-generator');
 
 module.exports = yeoman.Base.extend({
@@ -52,7 +53,7 @@ module.exports = yeoman.Base.extend({
     writing: function writing() {
         [
             '.gitignore',
-            '.eslintrc.json',
+            '.eslintrc.yaml',
             '.eslintignore',
             'index.js',
             'CONTRIBUTING.md',

--- a/app/templates/eslintrc.json
+++ b/app/templates/eslintrc.json
@@ -1,3 +1,0 @@
-{
-    "extends": "screwdriver"
-}

--- a/app/templates/eslintrc.yaml
+++ b/app/templates/eslintrc.yaml
@@ -1,0 +1,1 @@
+extends: screwdriver

--- a/app/templates/test/index.test.js
+++ b/app/templates/test/index.test.js
@@ -1,3 +1,4 @@
+'use strict';
 const assert = require('chai').assert;
 
 describe('index test', () => {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^2.10.2",
-    "eslint-config-screwdriver": "^1.0.0",
+    "eslint-config-screwdriver": "^1.0.1",
     "eslint-plugin-import": "^1.8.0",
     "eslint-plugin-jsx-a11y": "^1.2.2",
     "eslint-plugin-react": "^5.1.1",

--- a/test/app.js
+++ b/test/app.js
@@ -1,3 +1,4 @@
+'use strict';
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
@@ -18,7 +19,7 @@ describe('generator-screwdriver:app', () => {
     it('creates files', () => {
         assert.file([
             '.gitignore',
-            '.eslintrc.json',
+            '.eslintrc.yaml',
             '.eslintignore',
             'index.js',
             'LICENSE',


### PR DESCRIPTION
* Uses yaml form of eslint config.
* Fixes remaining lint errors with templates.