### PR TITLE
Automate adding of labels to Github repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 
 This Yeoman generator creates a new npm module pre-loaded with:
  - License
- - Readme with a variety of badges
+ - README with a variety of badges
  - Contributing doc
  - JSCS and JSHint configs
  - Wercker config with CD support
+ - Labels for your Github issues and pull requests
 
 ## Usage
 

--- a/app/defaults/labels.json
+++ b/app/defaults/labels.json
@@ -1,0 +1,27 @@
+[
+  { "name": "change/major", "color": "#FF8707" },
+  { "name": "change/minor", "color": "#FFB850" },
+  { "name": "change/patch", "color": "#FFCCB3" },
+
+  { "name": "feedback/help wanted", "color": "#FF389F" },
+  { "name": "feedback/question", "color": "#FF389F" },
+
+  { "name": "priority/high", "color": "#EE3F46" },
+  { "name": "priority/low", "color": "#91ca55" },
+  { "name": "priority/medium", "color": "#fbca04" },
+
+  { "name": "review/with reporter", "color": "#5EBEFF" },
+  { "name": "review/with team", "color": "#5EBEFF" },
+
+  { "name": "status/approved", "color": "#c2e0c6" },
+  { "name": "status/blocked", "color": "#000000" },
+  { "name": "status/duplicate", "color": "#ffffff" },
+  { "name": "status/in progress", "color": "#fef2c0" },
+  { "name": "status/invalid", "color": "#ffffff" },
+  { "name": "status/wontfix", "color": "#ffffff" },
+
+  { "name": "type/bug", "color": "#c5def5" },
+  { "name": "type/documentation", "color": "#c5def5" },
+  { "name": "type/enhancement", "color": "#c5def5" },
+  { "name": "type/feature", "color": "#c5def5" }
+]

--- a/app/index.js
+++ b/app/index.js
@@ -1,4 +1,6 @@
 'use strict';
+const gitLabel = require('git-label');
+const labels = require('./defaults/labels.json');
 const yeoman = require('yeoman-generator');
 
 module.exports = yeoman.Base.extend({
@@ -41,6 +43,11 @@ module.exports = yeoman.Base.extend({
                 validate: function validate(key) {
                     return key.length === 32;
                 }
+            },
+            {
+                type: 'password',
+                name: 'token',
+                message: 'Github Token'
             }
         ];
 
@@ -79,6 +86,17 @@ module.exports = yeoman.Base.extend({
                 this.props
             );
         });
+    },
+
+    addLabels: function addLabels() {
+        const config = {
+            api: 'https://api.github.com',
+            repo: `screwdriver-cd/${this.props.name}`,
+            token: this.props.token
+        };
+
+        // add specified labels to a repo
+        gitLabel.add(config, labels);
     },
 
     install: function install() {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "app"
   ],
   "dependencies": {
+    "git-label": "^4.1.1",
     "yeoman-generator": "^0.23.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This way we do not need to manually add labels to each repo we create in screwdriver-cd
Resolves https://github.com/screwdriver-cd/screwdriver/issues/83


Using git-label npm package (https://www.npmjs.com/package/git-label)


Not sure if asking for a user token is a good idea in a generator..