### PR TITLE
Remove eslint-plugin-import

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -30,9 +30,8 @@
   ],
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.2.2",
-    "eslint-config-screwdriver": "^2.0.0",
-    "eslint-plugin-import": "^1.12.0",
+    "eslint": "^3.9.1",
+    "eslint-config-screwdriver": "^2.0.9",
     "jenkins-mocha": "^3.0.0"
   },
   "dependencies": {}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app/index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive"
+    "test": "jenkins-mocha --recursive --timeout=3000"
   },
   "repository": {
     "type": "git",
@@ -38,9 +38,8 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.2.2",
-    "eslint-config-screwdriver": "^2.0.0",
-    "eslint-plugin-import": "^2.0.0",
+    "eslint": "^3.9.1",
+    "eslint-config-screwdriver": "^2.0.9",
     "jenkins-mocha": "^3.0.4",
     "yeoman-assert": "^2.0.0",
     "yeoman-test": "^1.0.0"


### PR DESCRIPTION
It's unnecessary to declare a dep for the import plugin, since eslint-config-screwdriver does this already. Declaring it at a lower scope leads to weird issues when versions are out of sync.