### PR TITLE
Allow mocha 'this' to work in tests

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -61,6 +61,7 @@ module.exports = yeoman.Base.extend({
             'CONTRIBUTING.md',
             'LICENSE',
             'test/index.test.js',
+            'test/.eslintrc.yaml',
             'screwdriver.yaml'
         ].forEach((template) => {
             const from = /^\./.test(template) ? template.substr(1) : template;

--- a/app/templates/test/.eslintrc.yaml
+++ b/app/templates/test/.eslintrc.yaml
@@ -1,0 +1,4 @@
+extends: screwdriver
+rules:
+    func-names: off
+    prefer-arrow-callback: off

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app/index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive --timeout=3000"
+    "test": "jenkins-mocha --recursive"
   },
   "repository": {
     "type": "git",

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -1,0 +1,4 @@
+extends: screwdriver
+rules:
+    func-names: off
+    prefer-arrow-callback: off

--- a/test/app.js
+++ b/test/app.js
@@ -4,7 +4,9 @@ const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
 
-describe('generator-screwdriver:app', () => {
+describe('generator-screwdriver:app', function () {
+    this.timeout(3000);
+
     before(() => helpers.run(path.join(__dirname, '../app'))
             .withPrompts({
                 name: 'foo-bar',
@@ -28,6 +30,7 @@ describe('generator-screwdriver:app', () => {
             'package.json',
             'README.md',
             'test/index.test.js',
+            'test/.eslintrc.yaml',
             'screwdriver.yaml'
         ]);
     });


### PR DESCRIPTION
When using ES6 function shorthand in describe, and it methods of mocha, you lose the ability to use mocha functions on the 'this' variable.
This PR fixes this by adding an eslint config in the test directory, that allows ES5-style anonymous functions.