### PR TITLE
feat: include github templates

### DIFF
--- a/app/templates/.github/ISSUE_TEMPLATE.md
+++ b/app/templates/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,2 @@
+*Please note that we have all screwdriver-cd module issues consolidated in the screwdriver-cd/screwdriver repository*
+*Link to issues - https://github.com/screwdriver-cd/screwdriver/issues*

--- a/app/templates/.github/PULL_REQUEST_TEMPLATE.md
+++ b/app/templates/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Context
+
+<!-- Why do we need this PR? What was the reason that led you to make this change? -->
+
+## Objective
+
+<!-- What does this PR fix? What intentional changes will this PR make? -->
+
+## References
+
+<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->


### PR DESCRIPTION
## Context

Having templates for PRs helps maintain document the intentional changes that a PR introduces. This helps a lot with debugging features in the future, and for those who did not author the feature to determine a good remediation to related issues.

Issue templates help us by re-directing the issues to be opened against the main repository

## Objective

Create an initial version of templates for both issues & pull requests.

## References

* https://github.com/blog/2111-issue-and-pull-request-templates